### PR TITLE
return 0 (false) when the nominal glyph func returned .notdef

### DIFF
--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -381,10 +381,8 @@ cdef hb_bool_t _nominal_glyph_func(hb_font_t* font, void* font_data,
     cdef Font py_font = <Font>font_data
     glyph[0] = (<FontFuncs>py_font.funcs)._nominal_glyph_func(
         py_font, unicode, <object>user_data)
-    if glyph[0]:
-        return 1
-    else:
-        return 0
+    # If the glyph is .notdef, return false, else return true
+    return int(glyph[0] != 0)
 
 
 cdef class FontFuncs:

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -381,7 +381,10 @@ cdef hb_bool_t _nominal_glyph_func(hb_font_t* font, void* font_data,
     cdef Font py_font = <Font>font_data
     glyph[0] = (<FontFuncs>py_font.funcs)._nominal_glyph_func(
         py_font, unicode, <object>user_data)
-    return 1
+    if glyph[0]:
+        return 1
+    else:
+        return 0
 
 
 cdef class FontFuncs:


### PR DESCRIPTION
Fixes #23.