### PR TITLE
add callback support for vertical advance and vertical origin

### DIFF
--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -452,12 +452,12 @@ cdef class FontFuncs:
         self._glyph_v_advance_func = func
 
     def set_glyph_v_origin_func(self,
-                                 func: Callable[[
-                                     Font,
-                                     int,  # gid
-                                     object,  # user_data
-                                 ], (int, int, int)],  # success, v_origin_x, v_origin_y
-                                 user_data: object) -> None:
+                                func: Callable[[
+                                    Font,
+                                    int,  # gid
+                                    object,  # user_data
+                                ], (int, int, int)],  # success, v_origin_x, v_origin_y
+                                user_data: object) -> None:
         hb_font_funcs_set_glyph_v_origin_func(
             self._hb_ffuncs, _glyph_v_origin_func, <void*>user_data, NULL)
         self._glyph_v_origin_func = func

--- a/src/uharfbuzz/charfbuzz.pxd
+++ b/src/uharfbuzz/charfbuzz.pxd
@@ -150,6 +150,13 @@ cdef extern from "hb.h":
         hb_codepoint_t glyph,
         void* user_data)
     ctypedef hb_font_get_glyph_advance_func_t hb_font_get_glyph_h_advance_func_t;
+    ctypedef hb_font_get_glyph_advance_func_t hb_font_get_glyph_v_advance_func_t;
+    ctypedef hb_bool_t (*hb_font_get_glyph_origin_func_t) (
+        hb_font_t* font, void* font_data,
+        hb_codepoint_t glyph,
+        hb_position_t* x, hb_position_t* y,
+        void* user_data)
+    ctypedef hb_font_get_glyph_origin_func_t hb_font_get_glyph_v_origin_func_t;
     ctypedef hb_bool_t (*hb_font_get_glyph_name_func_t) (
         hb_font_t *font, void *font_data,
         hb_codepoint_t glyph,
@@ -163,6 +170,14 @@ cdef extern from "hb.h":
     void hb_font_funcs_set_glyph_h_advance_func(
         hb_font_funcs_t* ffuncs,
         hb_font_get_glyph_h_advance_func_t func,
+        void* user_data, hb_destroy_func_t destroy)
+    void hb_font_funcs_set_glyph_v_advance_func(
+        hb_font_funcs_t* ffuncs,
+        hb_font_get_glyph_v_advance_func_t func,
+        void* user_data, hb_destroy_func_t destroy)
+    void hb_font_funcs_set_glyph_v_origin_func(
+        hb_font_funcs_t* ffuncs,
+        hb_font_get_glyph_v_origin_func_t func,
         void* user_data, hb_destroy_func_t destroy)
     void hb_font_funcs_set_glyph_name_func (
         hb_font_funcs_t* ffuncs,


### PR DESCRIPTION
Informal test script + data:

[vert_test.zip](https://github.com/harfbuzz/uharfbuzz/files/4142246/vert_test.zip)

The vertical advance callback is identical to the horizontal advance. The vertical origin callback function is called like h and v advance callbacks, but must return a 3-tuple: `(success, x, y)`, `success` being a boolean.