### PR TITLE
Add support to set script and language with OT tags instead of ISO and BCP 47

### DIFF
--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -166,13 +166,13 @@ cdef class Buffer:
         hb_buffer_set_script(
             self._hb_buffer, hb_script_from_string(cstr, -1))
 
-    def set_ot_language(self, value: str):
+    def set_language_from_ot_tag(self, value: str):
         cdef bytes packed = value.encode()
         cdef char* cstr = packed
         hb_buffer_set_language(
             self._hb_buffer, hb_ot_tag_to_language(hb_tag_from_string(cstr, -1)))
 
-    def set_ot_script(self, value: str):
+    def set_script_from_ot_tag(self, value: str):
         cdef bytes packed = value.encode()
         cdef char* cstr = packed
         hb_buffer_set_script(

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -166,6 +166,18 @@ cdef class Buffer:
         hb_buffer_set_script(
             self._hb_buffer, hb_script_from_string(cstr, -1))
 
+    def set_ot_language(self, value: str):
+        cdef bytes packed = value.encode()
+        cdef char* cstr = packed
+        hb_buffer_set_language(
+            self._hb_buffer, hb_ot_tag_to_language(hb_tag_from_string(cstr, -1)))
+
+    def set_ot_script(self, value: str):
+        cdef bytes packed = value.encode()
+        cdef char* cstr = packed
+        hb_buffer_set_script(
+            self._hb_buffer, hb_ot_tag_to_script(hb_tag_from_string(cstr, -1)))
+
     def add_codepoints(self, codepoints: List[int],
                        item_offset: int = 0, item_length: int = -1) -> None:
         cdef unsigned int size = len(codepoints)

--- a/src/uharfbuzz/charfbuzz.pxd
+++ b/src/uharfbuzz/charfbuzz.pxd
@@ -39,6 +39,8 @@ cdef extern from "hb.h":
     hb_script_t hb_script_from_string(const char* str, int len)
     hb_tag_t hb_tag_from_string(const char* str, int len)
     void hb_tag_to_string(hb_tag_t tag, char* buf)
+    hb_language_t hb_ot_tag_to_language(hb_tag_t tag)
+    hb_script_t hb_ot_tag_to_script(hb_tag_t tag)
 
     ctypedef struct hb_user_data_key_t:
         pass

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -86,6 +86,11 @@ class TestBuffer:
         buf.language = "he-il"
         assert buf.language == "he-il"
 
+        buf.set_ot_script("mym2")
+        assert buf.script == "Mymr"
+
+        buf.set_ot_language("BGR")
+        assert buf.language == "bg"
 
 class TestShape:
     @pytest.mark.parametrize(

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -92,6 +92,7 @@ class TestBuffer:
         buf.set_ot_language("BGR")
         assert buf.language == "bg"
 
+
 class TestShape:
     @pytest.mark.parametrize(
         "string, expected",

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -86,10 +86,10 @@ class TestBuffer:
         buf.language = "he-il"
         assert buf.language == "he-il"
 
-        buf.set_ot_script("mym2")
+        buf.set_script_from_ot_tag("mym2")
         assert buf.script == "Mymr"
 
-        buf.set_ot_language("BGR")
+        buf.set_language_from_ot_tag("BGR")
         assert buf.language == "bg"
 
 


### PR DESCRIPTION
The current Buffer object has `script` and `language` properties, that use ISO-15924 and BCP 47 strings respectively.

However, when working directly with fonts, it is more convenient to use OT script and language tags.

I added this as setter methods, and not as properties, as it is not a 1-to-1 mapping.

This API allows me to fix justvanrossum/fontgoggles#68