### PR TITLE
Reproduce crash on Windows?

### DIFF
--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -264,10 +264,12 @@ cdef hb_blob_t* _reference_table_func(
 cdef class Face:
     cdef hb_face_t* _hb_face
     cdef object _reference_table_func
+    cdef object _blob
 
     def __cinit__(self, bytes blob, int index=0):
         cdef hb_blob_t* hb_blob
         if blob is not None:
+            self._blob = blob
             hb_blob = hb_blob_create(
                 blob, len(blob), HB_MEMORY_MODE_READONLY, NULL, NULL)
             self._hb_face = hb_face_create(hb_blob, index)

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -4,7 +4,7 @@ import pytest
 
 
 TESTDATA = Path(__file__).parent / "data"
-ADOBE_BLANK_TTF = (TESTDATA / "AdobeBlank.subset.ttf").read_bytes()
+ADOBE_BLANK_TTF_PATH = TESTDATA / "AdobeBlank.subset.ttf"
 
 
 @pytest.fixture
@@ -22,7 +22,7 @@ def blankfont():
         {gid=8, name="u1F4A9", code=0x1F4A9},  # PILE OF POO
     ]
     """
-    face = hb.Face(ADOBE_BLANK_TTF)
+    face = hb.Face(ADOBE_BLANK_TTF_PATH.read_bytes())
     font = hb.Font(face)
     upem = face.upem
     font.scale = (upem, upem)


### PR DESCRIPTION
I seem to get a crash on Windows if the original font data get gc-ed before the shaping is done. Let's see if AppVeyor can reproduce this.