### PR TITLE
Fix crash in message API

### DIFF
--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -77,11 +77,13 @@ cdef class GlyphPosition:
 
 cdef class Buffer:
     cdef hb_buffer_t* _hb_buffer
+    cdef object _message_callback
 
     def __cinit__(self):
         self._hb_buffer = hb_buffer_create()
         if not hb_buffer_allocation_successful(self._hb_buffer):
             raise MemoryError()
+        self._message_callback = None
 
     def __dealloc__(self):
         if self._hb_buffer is not NULL:
@@ -238,6 +240,7 @@ cdef class Buffer:
         hb_buffer_guess_segment_properties(self._hb_buffer)
 
     def set_message_func(self, callback) -> None:
+        self._message_callback = callback
         hb_buffer_set_message_func(self._hb_buffer, msgcallback, <void*>callback, NULL)
 
 

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -237,13 +237,7 @@ class TestCallbacks:
         buf = hb.Buffer()
         buf.add_str(string)
         buf.guess_segment_properties()
-
-        messages = []
-        infos_trace = []
-        positions_trace = []
-
         message_collector = MessageCollector()
-
         buf.set_message_func(message_collector.message)
         hb.shape(blankfont, buf)
 

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -232,6 +232,27 @@ class TestCallbacks:
         assert advances_trace == [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0],
                                   [0, 0, 0, 0, 0], [0, 0, 0, 100, 0]]
 
+    def test_message_func_crash(self, blankfont):
+        string = "edcba"
+        buf = hb.Buffer()
+        buf.add_str(string)
+        buf.guess_segment_properties()
+
+        messages = []
+        infos_trace = []
+        positions_trace = []
+
+        message_collector = MessageCollector()
+
+        buf.set_message_func(message_collector.message)
+        hb.shape(blankfont, buf)
+
+
+class MessageCollector:
+    def message(self, message):
+        pass
+
+
 class TestGetBaseline:
     # The test font contains a BASE table with some test values
     def test_ot_layout_get_baseline_invalid_tag(self, blankfont):


### PR DESCRIPTION
If a method was used for the message callback, uharfbuzz would crash. Fixed by keeping a reference to the callback object.