### PR TITLE
Add harfbuzz_version function; update to HB 2.6.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ project(uharfbuzz_skbuild)
 
 include(ExternalProject)
 
-set(HARFBUZZ_VERSION "2.6.4")
-set(HARFBUZZ_SHA256 "9413b8d96132d699687ef914ebb8c50440efc87b3f775d25856d7ec347c03c12")
+set(HARFBUZZ_VERSION "2.6.5")
+set(HARFBUZZ_SHA256 "126ea030bcb66fca518d43162443d337e60933c3729c23f8a25da3a1c7371dfd")
 
 # download, configure, build and install harbfuzz static library
 ExternalProject_Add(

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -26,6 +26,11 @@ cdef int msgcallback(hb_buffer_t *buffer, hb_font_t *font, const char* message, 
     return 1
 
 
+def harfbuzz_version() -> str:
+    cdef const char* cstr = hb_version_string()
+    cdef bytes packed = cstr
+    return packed.decode()
+
 cdef class GlyphInfo:
     cdef hb_glyph_info_t _hb_glyph_info
     # could maybe store Buffer to prevent GC

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -26,7 +26,7 @@ cdef int msgcallback(hb_buffer_t *buffer, hb_font_t *font, const char* message, 
     return 1
 
 
-def harfbuzz_version() -> str:
+def version_string() -> str:
     cdef const char* cstr = hb_version_string()
     cdef bytes packed = cstr
     return packed.decode()

--- a/src/uharfbuzz/charfbuzz.pxd
+++ b/src/uharfbuzz/charfbuzz.pxd
@@ -41,6 +41,7 @@ cdef extern from "hb.h":
     void hb_tag_to_string(hb_tag_t tag, char* buf)
     hb_language_t hb_ot_tag_to_language(hb_tag_t tag)
     hb_script_t hb_ot_tag_to_script(hb_tag_t tag)
+    const char* hb_version_string();
 
     ctypedef struct hb_user_data_key_t:
         pass

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -298,3 +298,8 @@ class TestGetTags:
     def test_ot_layout_script_get_language_tags(self, blankfont):
         tags = hb.ot_layout_script_get_language_tags(blankfont.face, "GPOS", 0)
         assert tags == []
+
+
+def test_harfbuzz_version():
+    v = hb.harfbuzz_version()
+    assert isinstance(v, str)

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -301,5 +301,5 @@ class TestGetTags:
 
 
 def test_harfbuzz_version():
-    v = hb.harfbuzz_version()
+    v = hb.version_string()
     assert isinstance(v, str)


### PR DESCRIPTION
- add `harfbuzz_function` function to top-level `uharfbuzz`
- add test for above
- update underlying HarfBuzz to 2.6.5
