### PR TITLE
Add an option for linking against system library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,24 +13,34 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-define_macros = [('HB_NO_MT', '1')]
+define_macros = []
 linetrace = False
 if int(os.environ.get('CYTHON_LINETRACE', '0')):
     linetrace = True
     define_macros.append(('CYTHON_TRACE_NOGIL', '1'))
 
 extra_compile_args = []
-if platform.system() != 'Windows':
-    extra_compile_args.append('-std=c++11')
 
-extension = Extension(
-    'uharfbuzz._harfbuzz',
-    define_macros=define_macros,
-    include_dirs=['harfbuzz/src'],
-    sources=['src/uharfbuzz/_harfbuzz.pyx', 'harfbuzz/src/harfbuzz.cc'],
-    language='c++',
-    extra_compile_args=extra_compile_args,
-)
+if not os.environ.get('USE_SYSTEM_HARFBUZZ'):
+    if platform.system() != 'Windows':
+        extra_compile_args.append('-std=c++11')
+    extension = Extension(
+        'uharfbuzz._harfbuzz',
+        define_macros=[('HB_NO_MT', '1')] + define_macros,
+        include_dirs=['harfbuzz/src'],
+        sources=['src/uharfbuzz/_harfbuzz.pyx', 'harfbuzz/src/harfbuzz.cc'],
+        language='c++',
+        extra_compile_args=extra_compile_args,
+    )
+else:
+    extension = Extension(
+        'uharfbuzz._harfbuzz',
+        define_macros=define_macros,
+        include_dirs=['/usr/include/harfbuzz'],
+        libraries=['harfbuzz'],
+        sources=['src/uharfbuzz/_harfbuzz.pyx'],
+        extra_compile_args=extra_compile_args,
+    )
 
 setup(
     name="uharfbuzz",


### PR DESCRIPTION
Fixes #45, maybe can or should be default on Linux? Maybe not as that makes tests to fail depending on system version, some help on how to put it on CI would be nice, I am testing it locally using `USE_SYSTEM_HARFBUZZ=1 pip install . && pytest` which makes tests fail which is correct as my local harfbuzz installation isn't 2.6.8.