### PR TITLE
Install cython in CI environment before attempting source distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ branches:
 install:
   - $PYTHON -m pip install $PIP_INSTALL_OPTIONS pip
   - $PYTHON -m pip install $PIP_INSTALL_OPTIONS cibuildwheel==1.1.0
+  - $PYTHON -m pip install $PIP_INSTALL_OPTIONS setuptools_scm
 
 script:
   - $PYTHON -m cibuildwheel --output-dir wheelhouse
@@ -39,7 +40,6 @@ script:
     if [[ $TRAVIS_TAG ]]; then
       $PYTHON -m pip install $PIP_INSTALL_OPTIONS twine
       if [[ $TRAVIS_OS_NAME == osx ]]; then
-        $PYTHON -m pip install $PIP_INSTALL_OPTIONS setuptools
         $PYTHON setup.py sdist
         $PYTHON -m twine upload dist/*.zip
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
     if [[ $TRAVIS_TAG ]]; then
       $PYTHON -m pip install $PIP_INSTALL_OPTIONS twine
       if [[ $TRAVIS_OS_NAME == osx ]]; then
+        $PYTHON -m pip install $PIP_INSTALL_OPTIONS cython
         $PYTHON setup.py sdist
         $PYTHON -m twine upload dist/*.zip
       fi


### PR DESCRIPTION
Closes #59

My understanding from the discussion there is that installing setuptools by hand is unnecessary, but than installing cython is.

I don't really have a way to test that this is going to work, so please review carefully @anthrotype!