### PR TITLE
Include Harfbuzz sources in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include harfbuzz/src/*


### PR DESCRIPTION
Closes #61.

Relevant Python [docs here](https://packaging.python.org/guides/using-manifest-in/).

Tested locally by building a source dist (`python setup.py sdist`), then extracting the zip to a new folder and building (`python setup.py build`).