### PR TITLE
Short-list just the Harfbuzz sources we need

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
-include harfbuzz/src/*
+include harfbuzz/src/*.cc
+include harfbuzz/src/*.h
+include harfbuzz/src/*.hh


### PR DESCRIPTION
The GNU Make, Cmake, Python scripts, and other random stuff in
Harfbuzz's source directory are not relevant to the cython build which
only uses the amalgam file (harfbuzz.cc) and compiles it using a c++
compiler directly. This includes the other sources and header files, but
doesn't need any of the build machinery.

See discussion on #62.

No need to release for this as 0.13.2 isn't broken. This is just a tidy set of sources for next time.