### PR TITLE
Implement a more Pythonic feature slice notation

### DIFF
--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -588,7 +588,7 @@ def shape(font: Font, buffer: Buffer,
     cdef char* cstr
     cdef hb_feature_t feat
     cdef const char **c_shapers
-    if features is None:
+    if not features:
         size = 0
         hb_features = NULL
     else:

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -3,7 +3,7 @@ from enum import IntEnum
 from .charfbuzz cimport *
 from libc.stdlib cimport free, malloc
 from libc.string cimport const_char
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Sequence, Tuple, Union
 
 
 cdef extern from "Python.h":
@@ -579,7 +579,8 @@ cdef const char ** to_cstring_array(list_str):
     return ret
 
 
-def shape(font: Font, buffer: Buffer, features: Dict[str, bool] = None,
+def shape(font: Font, buffer: Buffer,
+        features: Dict[str,Union[int,bool,Sequence[Tuple[int,int,Union[int,bool]]]]] = None,
         shapers: List[str] = None) -> None:
     cdef unsigned int size
     cdef hb_feature_t* hb_features
@@ -591,14 +592,30 @@ def shape(font: Font, buffer: Buffer, features: Dict[str, bool] = None,
         size = 0
         hb_features = NULL
     else:
-        size = len(features)
+        size = 0
+        for name, value in features.items():
+            if isinstance(value, int):
+                size += 1
+            else:
+                size += len(value)
         hb_features = <hb_feature_t*>malloc(size * sizeof(hb_feature_t))
-        for i, (name, value) in enumerate(features.items()):
+        i = 0
+        for name, value in features.items():
+            assert i < size, "index out of range for feature array capacity"
             packed = name.encode()
             cstr = packed
             hb_feature_from_string(packed, len(packed), &feat)
-            feat.value = value
-            hb_features[i] = feat
+            if isinstance(value, int):
+                feat.value = value
+                hb_features[i] = feat
+                i += 1
+            else:
+                for start, end, value in value:
+                    feat.value = value
+                    feat.start = start
+                    feat.end = end
+                    hb_features[i] = feat
+                    i += 1
     if shapers:
         c_shapers = to_cstring_array(shapers)
         hb_shape_full(font._hb_font, buffer._hb_buffer, hb_features, size, c_shapers)

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -585,7 +585,6 @@ def shape(font: Font, buffer: Buffer,
     cdef unsigned int size
     cdef hb_feature_t* hb_features
     cdef bytes packed
-    cdef char* cstr
     cdef hb_feature_t feat
     cdef const char **c_shapers
     if not features:
@@ -603,7 +602,6 @@ def shape(font: Font, buffer: Buffer,
         for name, value in features.items():
             assert i < size, "index out of range for feature array capacity"
             packed = name.encode()
-            cstr = packed
             if isinstance(value, int):
                 hb_feature_from_string(packed, len(packed), &feat)
                 feat.value = value

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -591,7 +591,6 @@ def shape(font: Font, buffer: Buffer,
     hb_features = NULL
     try:
         if features:
-            size = 0
             for value in features.values():
                 if isinstance(value, int):
                     size += 1

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -593,7 +593,7 @@ def shape(font: Font, buffer: Buffer,
         hb_features = NULL
     else:
         size = 0
-        for name, value in features.items():
+        for value in features.values():
             if isinstance(value, int):
                 size += 1
             else:

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -604,12 +604,13 @@ def shape(font: Font, buffer: Buffer,
             assert i < size, "index out of range for feature array capacity"
             packed = name.encode()
             cstr = packed
-            hb_feature_from_string(packed, len(packed), &feat)
             if isinstance(value, int):
+                hb_feature_from_string(packed, len(packed), &feat)
                 feat.value = value
                 hb_features[i] = feat
                 i += 1
             else:
+                feat.tag = hb_tag_from_string(packed, -1)
                 for start, end, value in value:
                     feat.value = value
                     feat.start = start

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -196,6 +196,24 @@ class TestShape:
         assert glyph_names == expected
         assert blankfont.glyph_to_string(1000) == 'gid1000'
 
+    @pytest.mark.parametrize(
+        "string, features, expected",
+        [
+            # The calt feature replaces c by a in the context e, d, c', b, a.
+            ("edcbaedcba", {}, ["e", "d", "a", "b", "a", "e", "d", "a", "b", "a"]),
+            ("edcbaedcba", {"calt[2]": False}, ["e", "d", "c", "b", "a", "e", "d", "a", "b", "a"]),
+            ("edcbaedcba", {"calt": [(7, 8, False)]}, ["e", "d", "a", "b", "a", "e", "d", "c", "b", "a"]),
+        ],
+    )
+    def test_features_slice(self, blankfont, string, features, expected):
+        buf = hb.Buffer()
+        buf.add_str(string)
+        buf.guess_segment_properties()
+        hb.shape(blankfont, buf, features)
+
+        glyph_names = [blankfont.glyph_to_string(g.codepoint) for g in buf.glyph_infos]
+        assert glyph_names == expected
+
 
 class TestCallbacks:
     def test_nominal_glyph_func(self, blankfont):

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -203,6 +203,7 @@ class TestShape:
             ("edcbaedcba", {}, ["e", "d", "a", "b", "a", "e", "d", "a", "b", "a"]),
             ("edcbaedcba", {"calt[2]": False}, ["e", "d", "c", "b", "a", "e", "d", "a", "b", "a"]),
             ("edcbaedcba", {"calt": [(7, 8, False)]}, ["e", "d", "a", "b", "a", "e", "d", "c", "b", "a"]),
+            ("edcbaedcba", {"calt": [(0, 10, False), (7, 8, True)]}, ["e", "d", "c", "b", "a", "e", "d", "a", "b", "a"]),
         ],
     )
     def test_features_slice(self, blankfont, string, features, expected):


### PR DESCRIPTION
As discussed in #64.

The test case is a little overcomplicated because the only GSUB feature available is one `calt` feature.

This does _not_ remove the existing `features={"aalt[2]": 3}` notation, as that would not be backwards compatible. (I hadn't realized this worked at all until now, so I don't personally care for that notation.)