### PR TITLE
As per #66, calling hb.ot_font_set_funcs() is redundant

### DIFF
--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -27,7 +27,6 @@ def blankfont():
     font = hb.Font(face)
     upem = face.upem
     font.scale = (upem, upem)
-    hb.ot_font_set_funcs(font)
     return font
 
 
@@ -43,7 +42,6 @@ def opensans():
     font = hb.Font(face)
     upem = face.upem
     font.scale = (upem, upem)
-    hb.ot_font_set_funcs(font)
     return font
 
 


### PR DESCRIPTION
Similar to #66 and #67, remove redundant calls to hb.ot_font_set_funcs()