### PR TITLE
hb_language_to_string can return NULL

### DIFF
--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -158,7 +158,7 @@ cdef class Buffer:
         cdef const_char* cstr = hb_language_to_string(
             hb_buffer_get_language(self._hb_buffer))
         if cstr is NULL:
-            return ''
+            return None
         cdef bytes packed = cstr
         return packed.decode()
 
@@ -174,6 +174,8 @@ cdef class Buffer:
         cdef char cstr[5]
         hb_tag_to_string(hb_buffer_get_script(self._hb_buffer), cstr)
         cstr[4] = b'\0'
+        if cstr[0] == b'\0':
+            return None
         cdef bytes packed = cstr
         return packed.decode()
 

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -157,6 +157,8 @@ cdef class Buffer:
     def language(self) -> str:
         cdef const_char* cstr = hb_language_to_string(
             hb_buffer_get_language(self._hb_buffer))
+        if cstr is NULL:
+            return ''
         cdef bytes packed = cstr
         return packed.decode()
 

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -123,6 +123,12 @@ class TestBuffer:
         buf.set_language_from_ot_tag("BGR")
         assert buf.language == "bg"
 
+    def test_empty_buffer_props(self):
+        buf = hb.Buffer()
+        assert buf.script == ""
+        assert buf.language == ""
+        assert buf.direction == "invalid"
+
     def test_cluster_level(self):
         buf = hb.Buffer()
 

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -125,8 +125,8 @@ class TestBuffer:
 
     def test_empty_buffer_props(self):
         buf = hb.Buffer()
-        assert buf.script == ""
-        assert buf.language == ""
+        assert buf.script == None
+        assert buf.language == None
         assert buf.direction == "invalid"
 
     def test_cluster_level(self):


### PR DESCRIPTION
Return empty string in this case (for consistency with Buffer.script), but may be we should return None instead.

Fixes https://github.com/harfbuzz/uharfbuzz/issues/89