### PR TITLE
Respect return value from message callback function

### DIFF
--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -24,8 +24,10 @@ cdef extern from "Python.h":
 
 
 cdef int msgcallback(hb_buffer_t *buffer, hb_font_t *font, const char* message, void* userdata):
-    (<object>userdata)(message.decode('utf-8'))
-    return 1
+    ret = (<object>userdata)(message.decode('utf-8'))
+    if ret is None:
+        return 1
+    return ret
 
 
 def version_string() -> str:


### PR DESCRIPTION
For backward compatibility we treat None as True.
Fixes https://github.com/harfbuzz/uharfbuzz/issues/51