### PR TITLE
Revert "ci.yml: skip building wheel on pypy3"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
-      # skip 2.7, 3.4 and 3.5 and pypy; only build for >= 3.6 64-bit
-      CIBW_SKIP: "cp27-* cp33-* cp34-* cp35-* *-manylinux_i686 pp*"
+      # skip 2.7, 3.4 and 3.5: for now, only build for >= 3.6 64-bit
+      CIBW_SKIP: "cp27-* cp33-* cp34-* cp35-* *-manylinux_i686"
       CIBW_TEST_REQUIRES: "pytest"
       CIBW_TEST_COMMAND: "pushd {project} && pytest"
       CIBW_MANYLINUX_X86_64_IMAGE: "manylinux1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ configuration: Release
 environment:
   global:
     PYTHON: "C:\\Python37-x64"
-    # skip 2.7, 3.4 and 3.5 and pypy3; only build for >= 3.6
-    CIBW_SKIP: "cp27-* cp33-* cp34-* cp35-* pp*"
+    # skip 2.7, 3.4 and 3.5: for now, only build for >= 3.6
+    CIBW_SKIP: "cp27-* cp33-* cp34-* cp35-*"
     CIBW_TEST_REQUIRES: "pytest"
     CIBW_TEST_COMMAND: "cd {project} && pytest"
     TWINE_USERNAME: "anthrotype"


### PR DESCRIPTION
This reverts commit 4872a53e225e86a1264563a54f3efc55b362f696.

The original bug should be fixed now.