### PR TITLE
Raise on failure in Blob.from_file_path()

### DIFF
--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -38,6 +38,11 @@ def version_string() -> str:
     cdef bytes packed = cstr
     return packed.decode()
 
+
+class HarfBuzzError(Exception):
+    pass
+
+
 cdef class GlyphInfo:
     cdef hb_glyph_info_t _hb_glyph_info
     # could maybe store Buffer to prevent GC
@@ -293,8 +298,11 @@ cdef class Blob:
     @classmethod
     def from_file_path(cls, filename: Union[str, Path]):
         cdef bytes packed = os.fsencode(filename)
+        cdef hb_blob_t* blob = hb_blob_create_from_file_or_fail(<char*>packed)
+        if blob == NULL:
+            raise HarfBuzzError(f"Failed to open: {filename}")
         cdef Blob inst = cls(None)
-        inst._hb_blob = hb_blob_create_from_file(<char*>packed)
+        inst._hb_blob = blob
         return inst
 
     def __dealloc__(self):

--- a/src/uharfbuzz/charfbuzz.pxd
+++ b/src/uharfbuzz/charfbuzz.pxd
@@ -85,6 +85,9 @@ cdef extern from "hb.h":
     hb_blob_t* hb_blob_create_from_file(
         const char *file_name)
 
+    hb_blob_t* hb_blob_create_from_file_or_fail(
+        const char *file_name)
+
     void hb_blob_destroy(hb_blob_t* blob)
 
     const char* hb_blob_get_data(

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -162,6 +162,12 @@ class TestBuffer:
         assert buf.cluster_level == 1
 
 
+class TestBlob:
+    def test_from_file_path_fail(self):
+        with pytest.raises(hb.HarfBuzzError, match="Failed to open: DOES-NOT-EXIST"):
+            blob = hb.Blob.from_file_path("DOES-NOT-EXIST")
+
+
 class TestFont:
     def test_get_glyph_extents(self, opensans):
         # <TTGlyph name="A" xMin="0" yMin="0" xMax="1296" yMax="1468">


### PR DESCRIPTION
By using `hb_blob_create_from_file_or_fail()` and raising when it returns `NULL`.

Fixes https://github.com/harfbuzz/uharfbuzz/issues/116