### PR TITLE
add support for get/set of ppem and ptem

### DIFF
--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -425,6 +425,25 @@ cdef class Font:
         x, y = value
         hb_font_set_scale(self._hb_font, x, y)
 
+    @property
+    def ppem(self) -> Tuple[int, int]:
+        cdef unsigned int x, y
+        hb_font_get_ppem(self._hb_font, &x, &y)
+        return (x, y)
+
+    @ppem.setter
+    def ppem(self, value: Tuple[int, int]):
+        x, y = value
+        hb_font_set_ppem(self._hb_font, x, y)
+
+    @property
+    def ptem(self) -> float:
+        return hb_font_get_ptem(self._hb_font)
+
+    @ptem.setter
+    def ptem(self, value: float):
+        hb_font_set_ptem(self._hb_font, value)
+
     def set_variations(self, variations: Dict[str, float]) -> None:
         cdef unsigned int size
         cdef hb_variation_t* hb_variations

--- a/src/uharfbuzz/charfbuzz.pxd
+++ b/src/uharfbuzz/charfbuzz.pxd
@@ -274,6 +274,10 @@ cdef extern from "hb.h":
         void* font_data, hb_destroy_func_t destroy)
     void hb_font_get_scale(hb_font_t* font, int* x_scale, int* y_scale)
     void hb_font_set_scale(hb_font_t* font, int x_scale, int y_scale)
+    void hb_font_get_ppem(hb_font_t* font, unsigned int* x_ppem, unsigned int* y_ppem)
+    void hb_font_set_ppem(hb_font_t* font, unsigned int x_ppem, unsigned int y_ppem)
+    float hb_font_get_ptem(hb_font_t* font)
+    void hb_font_set_ptem(hb_font_t* font, float ptem)
     void hb_font_set_variations(
         hb_font_t* font,
         const hb_variation_t* variations,

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -224,6 +224,17 @@ class TestFont:
         with pytest.raises(TypeError):
             mutatorsans.set_var_coords_normalized(["a"])
 
+    def test_get_set_scale(self, blankfont):
+        blankfont.scale = (5, 7)
+        assert blankfont.scale == (5, 7)
+
+    def test_get_set_ppem(self, blankfont):
+        blankfont.ppem = (5, 7)
+        assert blankfont.ppem == (5, 7)
+
+    def test_get_set_ptem(self, blankfont):
+        blankfont.ptem = 7
+        assert blankfont.ptem == 7
 
 class TestShape:
     @pytest.mark.parametrize(


### PR DESCRIPTION
wrap `hb_font_get_ppem`, `hb_font_set_ppem`, `hb_font_get_ptem`, `hb_font_set_ptem` in a set of properties, similar to font scale.  for more details, see https://github.com/harfbuzz/uharfbuzz/issues/114

also add some trivial tests to make sure existence of API calls is checked