### PR TITLE
Add convenience Font.from_file_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ import uharfbuzz as hb
 fontfile = sys.argv[1]
 text = sys.argv[2]
 
-blob = hb.Blob.from_file_path(fontfile)
-face = hb.Face(blob)
-font = hb.Font(face)
+font = hb.Font.from_file_path(fontfile)
 
 buf = hb.Buffer()
 buf.add_str(text)

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -408,6 +408,23 @@ cdef class Font:
         cdef Font inst = cls(face)
         return inst
 
+    @classmethod
+    def from_file_path(cls, filename: Union[str, Path], face_index: int = 0):
+        """Returns a font object from a file path, with an optionally selected
+        face.
+
+        Convenient if all you want to load is a plain old TrueType or OpenType
+        flavored font (*.ttf, *.otf).
+        
+        Args:
+            * filename: The path to the font.
+            * face_index: Optionally, the face of the font when loading
+                TrueType/OpenType Collection fonts (*.ttc, *.otc).
+        """
+        blob = Blob.from_file_path(filename)
+        face = Face(blob, face_index)
+        return cls(face)
+
     @property
     def face(self):
         return self._face

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -409,7 +409,7 @@ cdef class Font:
         return inst
 
     @classmethod
-    def from_file_path(cls, filename: Union[str, Path], face_index: int = 0):
+    def from_file_path(cls, filename: os.PathLike[str], *, face_index: int = 0):
         """Returns a font object from a file path, with an optionally selected
         face.
 

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -26,10 +26,7 @@ def blankfont():
         {gid=8, name="u1F4A9", code=0x1F4A9},  # PILE OF POO
     ]
     """
-    blob = hb.Blob.from_file_path(ADOBE_BLANK_TTF_PATH)
-    face = hb.Face(blob)
-    font = hb.Font(face)
-    return font
+    return hb.Font.from_file_path(ADOBE_BLANK_TTF_PATH)
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 project_name = uharfbuzz
 envlist = py3,py3-cov,coverage
 skip_missing_interpreters = true
+isolated_build = true
 
 [testenv]
 skip_install =


### PR DESCRIPTION
Because why not.

Can't easily test this locally because I don't have Cython handy. I think tox.ini is missing an `isolated_build = true`.