### PR TITLE
Start using new setuptools config stuff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.x"
     - name: Install dependencies
@@ -43,17 +43,17 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.x"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade setuptools cython wheel twine
+        pip install --upgrade setuptools cython wheel twine build
     - name: Download artifacts from build jobs
       uses: actions/download-artifact@v2
       with:
@@ -108,5 +108,5 @@ jobs:
         else
           echo "DEBUG: This is a final release"
         fi
-        python setup.py sdist
+        python -m build --sdist
         twine upload dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,11 @@ jobs:
       with:
         python-version: "3.x"
     - name: Install dependencies
-      run: pip install cibuildwheel
+      run: pip install cibuildwheel twine
     - name: Build Wheels
-      run: python -m cibuildwheel --output-dir wheelhouse
+      run: |
+        python -m cibuildwheel --output-dir wheelhouse
+        twine check wheelhouse/*
     - uses: actions/upload-artifact@v2
       with:
         name: uharfbuzz-${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
     - name: Install dependencies
       run: pip install cibuildwheel twine
     - name: Build Wheels
-      run: |
-        python -m cibuildwheel --output-dir wheelhouse
-        twine check wheelhouse/*
+      run: python -m cibuildwheel --output-dir wheelhouse
+    - name: Check Wheels
+      run: twine check wheelhouse/*
     - uses: actions/upload-artifact@v2
       with:
         name: uharfbuzz-${{ matrix.os }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-recursive-include harfbuzz/src/ *.cc
-recursive-include harfbuzz/src/ *.h
-recursive-include harfbuzz/src/ *.hh
+recursive-include harfbuzz/src *.cc
+recursive-include harfbuzz/src *.h
+recursive-include harfbuzz/src *.hh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "uharfbuzz"
-description = "Streamlined Cython bindings for the harfbuzz shaping engine"
+description = "Streamlined Cython bindings for the HarfBuzz shaping engine"
 readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.5"
@@ -21,7 +21,7 @@ dynamic = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/trufont/uharfbuzz"
+Homepage = "https://github.com/harfbuzz/uharfbuzz"
 
 [tool.cibuildwheel]
 # only build for 64-bit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ license = {file = "LICENSE"}
 requires-python = ">=3.7"
 authors = [
     { name = "Adrien Tétar", email = "adri-from-59@hotmail.fr" },
+    { name = "Cosimo Lupo", email = "clupo@google.com" },
+    { name = "Just van Rossum", email = "justvanrossum@gmail.com" },
+    { name = "خالد حسني (Khaled Hosny)", email = "khaled@aliftype.com" },
 ]
 dynamic = [
     "version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "uharfbuzz"
 description = "Streamlined Cython bindings for the HarfBuzz shaping engine"
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.5"
+requires-python = ">=3.7"
 authors = [
     { name = "Adrien Tétar", email = "adri-from-59@hotmail.fr" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = {file = "LICENSE"}
 requires-python = ">=3.7"
 authors = [
     { name = "Adrien Tétar", email = "adri-from-59@hotmail.fr" },
-    { name = "Cosimo Lupo", email = "clupo@google.com" },
+    { name = "Cosimo Lupo", email = "cosimo@anthrotype.com" },
     { name = "Just van Rossum", email = "justvanrossum@gmail.com" },
     { name = "خالد حسني (Khaled Hosny)", email = "khaled@aliftype.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,27 @@
 [build-system]
 requires = [
-    "setuptools >= 36.4",
+    "setuptools >= 62.5",
     "wheel",
-    "setuptools_scm >= 2.1",
+    "setuptools_scm[toml] >= 6.2",
     "cython >= 0.28.1",
 ]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "uharfbuzz"
+description = "Streamlined Cython bindings for the harfbuzz shaping engine"
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.5"
+authors = [
+    { name = "Adrien Tétar", email = "adri-from-59@hotmail.fr" },
+]
+dynamic = [
+    "version",
+]
+
+[project.urls]
+Homepage = "https://github.com/trufont/uharfbuzz"
 
 [tool.cibuildwheel]
 # only build for 64-bit
@@ -16,3 +32,10 @@ test-command = "pytest {project}/tests"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]
+
+[tool.setuptools_scm]
+write_to = "src/uharfbuzz/_version.py"
+
+[tool.pytest.ini_options]
+addopts = "-v -r a"
+testpaths = "tests"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[sdist]
-formats = zip
-
-[metadata]
-license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
 import os
 import platform
-from io import open
 
 from Cython.Build import cythonize
 from setuptools import Extension, setup
-
-here = os.path.abspath(os.path.dirname(__file__))
 
 define_macros = [("HB_NO_MT", "1"), ("HB_EXPERIMENTAL_API", "1")]
 linetrace = False

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,43 @@
 #!/usr/bin/env python3
 import os
 import platform
-
-from Cython.Build import cythonize
 from setuptools import Extension, setup
+from Cython.Build import cythonize
 
-define_macros = [("HB_NO_MT", "1"), ("HB_EXPERIMENTAL_API", "1")]
+
+define_macros = [('HB_NO_MT', '1'), ('HB_EXPERIMENTAL_API', '1')]
 linetrace = False
-if int(os.environ.get("CYTHON_LINETRACE", "0")):
+if int(os.environ.get('CYTHON_LINETRACE', '0')):
     linetrace = True
-    define_macros.append(("CYTHON_TRACE_NOGIL", "1"))
+    define_macros.append(('CYTHON_TRACE_NOGIL', '1'))
 
 extra_compile_args = []
 extra_link_args = []
 libraries = []
-if platform.system() != "Windows":
-    extra_compile_args.append("-std=c++11")
-    define_macros.append(("HAVE_MMAP", "1"))
-    define_macros.append(("HAVE_UNISTD_H", "1"))
-    define_macros.append(("HAVE_SYS_MMAN_H", "1"))
+if platform.system() != 'Windows':
+    extra_compile_args.append('-std=c++11')
+    define_macros.append(('HAVE_MMAP', '1'))
+    define_macros.append(('HAVE_UNISTD_H', '1'))
+    define_macros.append(('HAVE_SYS_MMAN_H', '1'))
 else:
-    define_macros.append(("HAVE_DIRECTWRITE", "1"))
-    define_macros.append(("HAVE_UNISCRIBE", "1"))
-    libraries += ["usp10", "gdi32", "user32", "rpcrt4", "dwrite"]
+    define_macros.append(('HAVE_DIRECTWRITE', '1'))
+    define_macros.append(('HAVE_UNISCRIBE', '1'))
+    libraries += ['usp10', 'gdi32', 'user32', 'rpcrt4', 'dwrite']
 
-if platform.system() == "Darwin":
-    define_macros.append(("HAVE_CORETEXT", "1"))
-    extra_link_args.extend(["-framework", "ApplicationServices"])
+if platform.system() == 'Darwin':
+    define_macros.append(('HAVE_CORETEXT', '1'))
+    extra_link_args.extend(['-framework', 'ApplicationServices'])
 
 extension = Extension(
-    "uharfbuzz._harfbuzz",
+    'uharfbuzz._harfbuzz',
     define_macros=define_macros,
-    include_dirs=["harfbuzz/src"],
+    include_dirs=['harfbuzz/src'],
     sources=[
-        "src/uharfbuzz/_harfbuzz.pyx",
-        "harfbuzz/src/harfbuzz.cc",
-        "harfbuzz/src/hb-subset-repacker.cc",
+        'src/uharfbuzz/_harfbuzz.pyx',
+        'harfbuzz/src/harfbuzz.cc',
+        'harfbuzz/src/hb-subset-repacker.cc',
     ],
-    language="c++",
+    language='c++',
     libraries=libraries,
     extra_compile_args=extra_compile_args,
     extra_link_args=extra_link_args,
@@ -45,9 +45,9 @@ extension = Extension(
 
 setup(
     zip_safe=False,
-    ext_modules=cythonize(
+    ext_modules = cythonize(
         extension,
-        annotate=bool(int(os.environ.get("CYTHON_ANNOTATE", "0"))),
+        annotate=bool(int(os.environ.get('CYTHON_ANNOTATE', '0'))),
         compiler_directives={"linetrace": linetrace},
     ),
 )

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ extension = Extension(
 
 setup(
     zip_safe=False,
+    include_package_data=False, # Do not include Cython sources in wheel distributions.
     ext_modules = cythonize(
         extension,
         annotate=bool(int(os.environ.get('CYTHON_ANNOTATE', '0'))),

--- a/setup.py
+++ b/setup.py
@@ -1,74 +1,56 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-from io import open
 import os
-import sys
 import platform
-from setuptools import Extension, setup
+from io import open
+
 from Cython.Build import cythonize
+from setuptools import Extension, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-# Get the long description from the README file
-with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
-
-define_macros = [('HB_NO_MT', '1'), ('HB_EXPERIMENTAL_API', '1')]
+define_macros = [("HB_NO_MT", "1"), ("HB_EXPERIMENTAL_API", "1")]
 linetrace = False
-if int(os.environ.get('CYTHON_LINETRACE', '0')):
+if int(os.environ.get("CYTHON_LINETRACE", "0")):
     linetrace = True
-    define_macros.append(('CYTHON_TRACE_NOGIL', '1'))
+    define_macros.append(("CYTHON_TRACE_NOGIL", "1"))
 
 extra_compile_args = []
 extra_link_args = []
 libraries = []
-if platform.system() != 'Windows':
-    extra_compile_args.append('-std=c++11')
-    define_macros.append(('HAVE_MMAP', '1'))
-    define_macros.append(('HAVE_UNISTD_H', '1'))
-    define_macros.append(('HAVE_SYS_MMAN_H', '1'))
+if platform.system() != "Windows":
+    extra_compile_args.append("-std=c++11")
+    define_macros.append(("HAVE_MMAP", "1"))
+    define_macros.append(("HAVE_UNISTD_H", "1"))
+    define_macros.append(("HAVE_SYS_MMAN_H", "1"))
 else:
-    define_macros.append(('HAVE_DIRECTWRITE', '1'))
-    define_macros.append(('HAVE_UNISCRIBE', '1'))
-    libraries += ['usp10', 'gdi32', 'user32', 'rpcrt4', 'dwrite']
+    define_macros.append(("HAVE_DIRECTWRITE", "1"))
+    define_macros.append(("HAVE_UNISCRIBE", "1"))
+    libraries += ["usp10", "gdi32", "user32", "rpcrt4", "dwrite"]
 
-if platform.system() == 'Darwin':
-    define_macros.append(('HAVE_CORETEXT', '1'))
-    extra_link_args.extend(['-framework', 'ApplicationServices'])
+if platform.system() == "Darwin":
+    define_macros.append(("HAVE_CORETEXT", "1"))
+    extra_link_args.extend(["-framework", "ApplicationServices"])
 
 extension = Extension(
-    'uharfbuzz._harfbuzz',
+    "uharfbuzz._harfbuzz",
     define_macros=define_macros,
-    include_dirs=['harfbuzz/src'],
+    include_dirs=["harfbuzz/src"],
     sources=[
-        'src/uharfbuzz/_harfbuzz.pyx',
-        'harfbuzz/src/harfbuzz.cc',
-        'harfbuzz/src/hb-subset-repacker.cc',
+        "src/uharfbuzz/_harfbuzz.pyx",
+        "harfbuzz/src/harfbuzz.cc",
+        "harfbuzz/src/hb-subset-repacker.cc",
     ],
-    language='c++',
+    language="c++",
     libraries=libraries,
     extra_compile_args=extra_compile_args,
     extra_link_args=extra_link_args,
 )
 
 setup(
-    name="uharfbuzz",
-    use_scm_version={"write_to": "src/uharfbuzz/_version.py"},
-    description="Streamlined Cython bindings for the harfbuzz shaping engine",
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    author="Adrien Tétar",
-    author_email="adri-from-59@hotmail.fr",
-    url="https://github.com/trufont/uharfbuzz",
-    license="Apache License 2.0",
-    package_dir={"": "src"},
-    packages=["uharfbuzz"],
     zip_safe=False,
-    setup_requires=["setuptools_scm"],
-    python_requires=">=3.5",
-    ext_modules = cythonize(
+    ext_modules=cythonize(
         extension,
-        annotate=bool(int(os.environ.get('CYTHON_ANNOTATE', '0'))),
+        annotate=bool(int(os.environ.get("CYTHON_ANNOTATE", "0"))),
         compiler_directives={"linetrace": linetrace},
     ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ setenv =
     cov: CYTHON_LINETRACE=1
 commands =
     !cov: pytest {posargs}
-    cov: python setup.py develop
+    cov: pip install -e .
     cov: coverage run --parallel -m pytest {posargs}
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 project_name = uharfbuzz
 envlist = py3,py3-cov,coverage
 skip_missing_interpreters = true
+isolated_build = true
 
 [testenv]
 skip_install =
@@ -50,21 +51,3 @@ changedir = {toxinidir}
 commands =
     coverage combine
     codecov --env TOXENV
-
-[testenv:wheel]
-description = build wheel package for upload to PyPI
-skip_install = true
-deps =
-    setuptools >= 36.4.0
-    pip >= 18.0
-    wheel >= 0.31.0
-changedir = {toxinidir}
-commands =
-    python -c 'import os, glob; whl = glob.glob(".tox/dist/*.whl"); whl and os.remove(whl[0])'
-    pip wheel --pre --no-deps --no-cache-dir --wheel-dir {distdir} --find-links {distdir} --no-binary {[tox]project_name} {[tox]project_name}
-
-[pytest]
-testpaths = tests/
-addopts =
-    -v
-    -r a


### PR DESCRIPTION
The packaging ecosystem is converging to using pyproject.toml for everything: https://setuptools.pypa.io/en/stable/userguide/pyproject_config.html

Here, I move stuff to using it, because I can.

The tox wheel env can go maybe, one can use [`build`](https://pypi.org/project/build/) instead.

Needs more testing.