### PR TITLE
keep uharfbuzz build functional once Cython 3.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade setuptools cython wheel twine
+        pip install --upgrade setuptools "cython<3.0" wheel twine
     - name: Download artifacts from build jobs
       uses: actions/download-artifact@v2
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools >= 36.4",
     "wheel",
     "setuptools_scm >= 2.1",
-    "cython >= 0.28.1",
+    "cython < 3.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
block Cython 3.0+ as a build dep