### PR TITLE
Build wheels for musl-based linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Build + Deploy
 on:
   push:
     branches: [main]
-    tags: ["v*.*.*"]
+    #tags: ["v*.*.*"]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Build + Deploy
 on:
   push:
     branches: [main]
-    #tags: ["v*.*.*"]
+    tags: ["v*.*.*"]
   pull_request:
     branches: [main]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 # only build for 64-bit
-skip = ["*-manylinux_i686", "*-musllinux_i686"]
+skip = ["*-manylinux*", "*-musllinux_i686"]
 
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
@@ -30,7 +30,7 @@ before-all = [
 before-test = "ccache --show-stats"
 
 [tool.cibuildwheel.linux.environment]
-CC = "/usr/lib64/ccache/gcc"
+CC = "/usr/lib/ccache/bin/gcc"
 CFLAGS = "-g0"
 
 [[tool.cibuildwheel.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,5 +35,5 @@ CFLAGS = "-g0"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
-before-all = "apk add ccache bash"
-CC = "/usr/lib/ccache/bin/gcc"
+before-all = "apk add ccache"
+environment = {CC = "/usr/lib/ccache/bin/gcc"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ CC = "/usr/local/opt/ccache/libexec/cc"
 
 [tool.cibuildwheel.linux]
 before-all = [
-    "yum install -y ccache",
+    "yum install -y ccache || apk add ccache",
     "ln -s $(which ccache) /usr/lib64/ccache/gcc",
 ]
 before-test = "ccache --show-stats"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ CC = "/usr/local/opt/ccache/libexec/cc"
 [tool.cibuildwheel.linux]
 before-all = [
     "yum install -y ccache",
-    "ln -s $(which ccache) /usr/lib64/ccache/gcc"
+    "ln -s $(which ccache) /usr/lib64/ccache/gcc",
 ]
 before-test = "ccache --show-stats"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 # only build for 64-bit
-skip = ["*-manylinux*", "*-musllinux_i686"]
+skip = ["*-manylinux_i686", "*-musllinux_i686"]
 
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
@@ -30,7 +30,7 @@ before-all = [
 before-test = "ccache --show-stats"
 
 [tool.cibuildwheel.linux.environment]
-CC = "/usr/lib/ccache/bin/gcc"
+CC = "/usr/lib64/ccache/gcc"
 CFLAGS = "-g0"
 
 [[tool.cibuildwheel.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,16 @@ CC = "/usr/local/opt/ccache/libexec/cc"
 
 [tool.cibuildwheel.linux]
 before-all = [
-    "yum install -y ccache && ln -s $(which ccache) /usr/lib64/ccache/gcc || apk add gcc"
+    "yum install -y ccache",
+    "ln -s $(which ccache) /usr/lib64/ccache/gcc"
 ]
 before-test = "ccache --show-stats"
 
 [tool.cibuildwheel.linux.environment]
 CC = "/usr/lib64/ccache/gcc"
 CFLAGS = "-g0"
+
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux*"
+before-all = "apk add ccache"
+CC = "/usr/lib/ccache/bin/gcc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 # only build for 64-bit
-skip = ["*-manylinux_i686"]
+skip = ["*-manylinux_i686", "*-musllinux_i686"]
 
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
@@ -35,5 +35,5 @@ CFLAGS = "-g0"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
-before-all = "apk add ccache"
+before-all = "apk add ccache bash"
 CC = "/usr/lib/ccache/bin/gcc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ CC = "/usr/local/opt/ccache/libexec/cc"
 
 [tool.cibuildwheel.linux]
 before-all = [
-    "yum install -y ccache || apk add ccache",
-    "ln -s $(which ccache) /usr/lib64/ccache/gcc",
+    "yum install -y ccache && ln -s $(which ccache) /usr/lib64/ccache/gcc || apk add gcc"
 ]
 before-test = "ccache --show-stats"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 # only build for 64-bit
-skip = ["*-manylinux_i686", "*-musllinux*"]
+skip = ["*-manylinux_i686"]
 
 test-requires = "pytest"
 test-command = "pytest {project}/tests"


### PR DESCRIPTION
It is still faster to build wheels for both `manylinux` and `musllinux` than windows and macos:

![image](https://github.com/harfbuzz/uharfbuzz/assets/3732628/f4166a4f-6f01-4443-83b2-907b881663e1)

Close #166 