### PR TITLE
Add support for ot-metrics

### DIFF
--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -1656,7 +1656,7 @@ class OTMetricsTag(IntEnum):
     UNDERLINE_OFFSET = HB_OT_METRICS_TAG_UNDERLINE_OFFSET
 
 def ot_metrics_get_position(font: Font,
-                            tag: OTMathTag) -> int:
+                            tag: OTMetricsTag) -> int:
     cdef hb_position_t hb_position
     cdef hb_bool_t success
     success = hb_ot_metrics_get_position(font._hb_font, tag, &hb_position)

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -1659,37 +1659,29 @@ def ot_metrics_get_position(font: Font,
                             tag: OTMetricsTag) -> int:
     cdef hb_position_t hb_position
     cdef hb_bool_t success
-    success = hb_ot_metrics_get_position(font._hb_font, tag, &hb_position)
-    if success:
+    if hb_ot_metrics_get_position(font._hb_font, tag, &hb_position):
         return hb_position
-    else:
-        return None
+    return None
 
 def ot_metrics_get_position_with_fallback(font: Font,
-                                          tag: OTMathTag) -> int:
+                                          tag: OTMetricsTag) -> int:
     cdef hb_position_t hb_position
-    success = hb_ot_metrics_get_position_with_fallback(font._hb_font,
+    hb_ot_metrics_get_position_with_fallback(font._hb_font,
                                                        tag,
                                                        &hb_position)
     return hb_position
 
 def ot_metrics_get_variation(font: Font,
                              tag: OTMathTag) -> float:
-    cdef float variation
-    variation = hb_ot_metrics_get_variation(font._hb_font, tag)
-    return variation
+    return hb_ot_metrics_get_variation(font._hb_font, tag)
 
 def ot_metrics_get_x_variation(font: Font,
-                               tag: OTMathTag) -> int:
-    cdef hb_position_t hb_position
-    hb_position = hb_ot_metrics_get_x_variation(font._hb_font, tag)
-    return hb_position
+                               tag: OTMetricsTag) -> int:
+    return hb_ot_metrics_get_x_variation(font._hb_font, tag)
 
 def ot_metrics_get_y_variation(font: Font,
-                               tag: OTMathTag) -> int:
-    cdef hb_position_t hb_position
-    hb_position = hb_ot_metrics_get_y_variation(font._hb_font, tag)
-    return hb_position
+                               tag: OTMetricsTag) -> int:
+    return hb_ot_metrics_get_y_variation(font._hb_font, tag)
 
 def ot_font_set_funcs(Font font):
     hb_ot_font_set_funcs(font._hb_font)

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -1624,6 +1624,73 @@ def ot_math_get_glyph_assembly(font: Font,
         start_offset += count
     return assembly, italics_correction
 
+
+class OTMetricsTag(IntEnum):
+    HORIZONTAL_ASCENDER = HB_OT_METRICS_TAG_HORIZONTAL_ASCENDER
+    HORIZONTAL_DESCENDER = HB_OT_METRICS_TAG_HORIZONTAL_DESCENDER
+    HORIZONTAL_LINE_GAP = HB_OT_METRICS_TAG_HORIZONTAL_LINE_GAP
+    HORIZONTAL_CLIPPING_ASCENT = HB_OT_METRICS_TAG_HORIZONTAL_CLIPPING_ASCENT
+    HORIZONTAL_CLIPPING_DESCENT = HB_OT_METRICS_TAG_HORIZONTAL_CLIPPING_DESCENT
+    VERTICAL_ASCENDER = HB_OT_METRICS_TAG_VERTICAL_ASCENDER
+    VERTICAL_DESCENDER = HB_OT_METRICS_TAG_VERTICAL_DESCENDER
+    VERTICAL_LINE_GAP = HB_OT_METRICS_TAG_VERTICAL_LINE_GAP
+    HORIZONTAL_CARET_RISE = HB_OT_METRICS_TAG_HORIZONTAL_CARET_RISE
+    HORIZONTAL_CARET_RUN = HB_OT_METRICS_TAG_HORIZONTAL_CARET_RUN
+    HORIZONTAL_CARET_OFFSET = HB_OT_METRICS_TAG_HORIZONTAL_CARET_OFFSET
+    VERTICAL_CARET_RISE = HB_OT_METRICS_TAG_VERTICAL_CARET_RISE
+    VERTICAL_CARET_RUN = HB_OT_METRICS_TAG_VERTICAL_CARET_RUN
+    VERTICAL_CARET_OFFSET = HB_OT_METRICS_TAG_VERTICAL_CARET_OFFSET
+    X_HEIGHT = HB_OT_METRICS_TAG_X_HEIGHT
+    CAP_HEIGHT = HB_OT_METRICS_TAG_CAP_HEIGHT
+    SUBSCRIPT_EM_X_SIZE = HB_OT_METRICS_TAG_SUBSCRIPT_EM_X_SIZE
+    SUBSCRIPT_EM_Y_SIZE = HB_OT_METRICS_TAG_SUBSCRIPT_EM_Y_SIZE
+    SUBSCRIPT_EM_X_OFFSET = HB_OT_METRICS_TAG_SUBSCRIPT_EM_X_OFFSET
+    SUBSCRIPT_EM_Y_OFFSET = HB_OT_METRICS_TAG_SUBSCRIPT_EM_Y_OFFSET
+    SUPERSCRIPT_EM_X_SIZE = HB_OT_METRICS_TAG_SUPERSCRIPT_EM_X_SIZE
+    SUPERSCRIPT_EM_Y_SIZE = HB_OT_METRICS_TAG_SUPERSCRIPT_EM_Y_SIZE
+    SUPERSCRIPT_EM_X_OFFSET = HB_OT_METRICS_TAG_SUPERSCRIPT_EM_X_OFFSET
+    SUPERSCRIPT_EM_Y_OFFSET = HB_OT_METRICS_TAG_SUPERSCRIPT_EM_Y_OFFSET
+    STRIKEOUT_SIZE = HB_OT_METRICS_TAG_STRIKEOUT_SIZE
+    STRIKEOUT_OFFSET = HB_OT_METRICS_TAG_STRIKEOUT_OFFSET
+    UNDERLINE_SIZE = HB_OT_METRICS_TAG_UNDERLINE_SIZE
+    UNDERLINE_OFFSET = HB_OT_METRICS_TAG_UNDERLINE_OFFSET
+
+def ot_metrics_get_position(font: Font,
+                            tag: OTMathTag) -> int:
+    cdef hb_position_t hb_position
+    cdef hb_bool_t success
+    success = hb_ot_metrics_get_position(font._hb_font, tag, &hb_position)
+    if success:
+        return hb_position
+    else:
+        return None
+
+def ot_metrics_get_position_with_fallback(font: Font,
+                                          tag: OTMathTag) -> int:
+    cdef hb_position_t hb_position
+    success = hb_ot_metrics_get_position_with_fallback(font._hb_font,
+                                                       tag,
+                                                       &hb_position)
+    return hb_position
+
+def ot_metrics_get_variation(font: Font,
+                             tag: OTMathTag) -> float:
+    cdef float variation
+    variation = hb_ot_metrics_get_variation(font._hb_font, tag)
+    return variation
+
+def ot_metrics_get_x_variation(font: Font,
+                               tag: OTMathTag) -> int:
+    cdef hb_position_t hb_position
+    hb_position = hb_ot_metrics_get_x_variation(font._hb_font, tag)
+    return hb_position
+
+def ot_metrics_get_y_variation(font: Font,
+                               tag: OTMathTag) -> int:
+    cdef hb_position_t hb_position
+    hb_position = hb_ot_metrics_get_y_variation(font._hb_font, tag)
+    return hb_position
+
 def ot_font_set_funcs(Font font):
     hb_ot_font_set_funcs(font._hb_font)
 

--- a/src/uharfbuzz/charfbuzz.pxd
+++ b/src/uharfbuzz/charfbuzz.pxd
@@ -1158,6 +1158,59 @@ cdef extern from "hb-ot.h":
         hb_ot_math_glyph_part_t *parts, # out
         hb_position_t *italics_correction) # out
 
+    # hb-ot-metrics.h
+    ctypedef enum hb_ot_metrics_tag_t:
+        HB_OT_METRICS_TAG_HORIZONTAL_ASCENDER
+        HB_OT_METRICS_TAG_HORIZONTAL_DESCENDER
+        HB_OT_METRICS_TAG_HORIZONTAL_LINE_GAP
+        HB_OT_METRICS_TAG_HORIZONTAL_CLIPPING_ASCENT
+        HB_OT_METRICS_TAG_HORIZONTAL_CLIPPING_DESCENT
+        HB_OT_METRICS_TAG_VERTICAL_ASCENDER
+        HB_OT_METRICS_TAG_VERTICAL_DESCENDER
+        HB_OT_METRICS_TAG_VERTICAL_LINE_GAP
+        HB_OT_METRICS_TAG_HORIZONTAL_CARET_RISE
+        HB_OT_METRICS_TAG_HORIZONTAL_CARET_RUN
+        HB_OT_METRICS_TAG_HORIZONTAL_CARET_OFFSET
+        HB_OT_METRICS_TAG_VERTICAL_CARET_RISE
+        HB_OT_METRICS_TAG_VERTICAL_CARET_RUN
+        HB_OT_METRICS_TAG_VERTICAL_CARET_OFFSET
+        HB_OT_METRICS_TAG_X_HEIGHT
+        HB_OT_METRICS_TAG_CAP_HEIGHT
+        HB_OT_METRICS_TAG_SUBSCRIPT_EM_X_SIZE
+        HB_OT_METRICS_TAG_SUBSCRIPT_EM_Y_SIZE
+        HB_OT_METRICS_TAG_SUBSCRIPT_EM_X_OFFSET
+        HB_OT_METRICS_TAG_SUBSCRIPT_EM_Y_OFFSET
+        HB_OT_METRICS_TAG_SUPERSCRIPT_EM_X_SIZE
+        HB_OT_METRICS_TAG_SUPERSCRIPT_EM_Y_SIZE
+        HB_OT_METRICS_TAG_SUPERSCRIPT_EM_X_OFFSET
+        HB_OT_METRICS_TAG_SUPERSCRIPT_EM_Y_OFFSET
+        HB_OT_METRICS_TAG_STRIKEOUT_SIZE
+        HB_OT_METRICS_TAG_STRIKEOUT_OFFSET
+        HB_OT_METRICS_TAG_UNDERLINE_SIZE
+        HB_OT_METRICS_TAG_UNDERLINE_OFFSET
+
+    hb_bool_t hb_ot_metrics_get_position(
+        hb_font_t *font,
+        hb_ot_metrics_tag_t metrics_tag,
+        hb_position_t *position);
+
+    void hb_ot_metrics_get_position_with_fallback(
+        hb_font_t *font,
+        hb_ot_metrics_tag_t metrics_tag,
+        hb_position_t *position);
+
+    float hb_ot_metrics_get_variation(
+        hb_font_t *font,
+        hb_ot_metrics_tag_t metrics_tag);
+
+    hb_position_t hb_ot_metrics_get_x_variation(
+        hb_font_t *font,
+        hb_ot_metrics_tag_t metrics_tag);
+
+    hb_position_t hb_ot_metrics_get_y_variation(
+        hb_font_t *font,
+        hb_ot_metrics_tag_t metrics_tag);
+
 cdef extern from "hb-subset-repacker.h":
     ctypedef struct hb_link_t:
         unsigned int width

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -1419,8 +1419,14 @@ class TestOTMetrics:
         assert hb.ot_metrics_get_variation(mutatorsans, hb.OTMetricsTag.CAP_HEIGHT) == 0
         mutatorsans.set_variations({"wdth": 250, "wght": 250})
         assert hb.ot_metrics_get_variation(mutatorsans, hb.OTMetricsTag.CAP_HEIGHT) == 25
-        mutatorsans.set_variations({"wdth": 0, "wght": 0})
 
+    def test_ot_metrics_get_x_variation(self, mutatorsans):
+        mutatorsans.set_variations({"wdth": 250, "wght": 250})
+        assert hb.ot_metrics_get_variation(mutatorsans, hb.OTMetricsTag.CAP_HEIGHT) == 25
+
+    def test_ot_metrics_get_y_variation(self, mutatorsans):
+        mutatorsans.set_variations({"wdth": 250, "wght": 250})
+        assert hb.ot_metrics_get_variation(mutatorsans, hb.OTMetricsTag.CAP_HEIGHT) == 25
 
 def test_harfbuzz_version():
     v = hb.version_string()

--- a/tests/test_uharfbuzz.py
+++ b/tests/test_uharfbuzz.py
@@ -1406,6 +1406,22 @@ class TestOTMath:
         assert (result, italics_correction) == expected
 
 
+class TestOTMetrics:
+    def test_ot_metrics_get_position(self, opensans):
+        assert hb.ot_metrics_get_position(opensans, hb.OTMetricsTag.HORIZONTAL_ASCENDER) == 2189
+        assert hb.ot_metrics_get_position(opensans, hb.OTMetricsTag.CAP_HEIGHT) == 1462
+        assert hb.ot_metrics_get_position(opensans, hb.OTMetricsTag.VERTICAL_CARET_RISE) is None
+
+    def test_ot_metrics_get_position_with_fallback(self, opensans):
+        assert hb.ot_metrics_get_position_with_fallback(opensans, hb.OTMetricsTag.VERTICAL_CARET_RISE) == 1
+
+    def test_ot_metrics_get_variation(self, mutatorsans):
+        assert hb.ot_metrics_get_variation(mutatorsans, hb.OTMetricsTag.CAP_HEIGHT) == 0
+        mutatorsans.set_variations({"wdth": 250, "wght": 250})
+        assert hb.ot_metrics_get_variation(mutatorsans, hb.OTMetricsTag.CAP_HEIGHT) == 25
+        mutatorsans.set_variations({"wdth": 0, "wght": 0})
+
+
 def test_harfbuzz_version():
     v = hb.version_string()
     assert isinstance(v, str)


### PR DESCRIPTION
Some test infrastructure I'm fooling with would benefit from this.

Hoping you might have some advice on whether or how I should test the x/y_variation functions, or if I should just delete those ...