### PR TITLE
add empty tool.setuptools_scm table to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+
 [tool.cibuildwheel]
 # Skip unsupported Python versions, and only build for 64-bit on Linux
 skip = ["cp36-*", "cp37-*", "*-manylinux_i686", "*-musllinux_i686"]


### PR DESCRIPTION
forgive the somewhat indirect/weird PR.

I ran into an issue trying to install pygfx into a centos docker container. It depends on uharfbuzz and presumably no wheel was available and so it tries to build from source, at which point I got this error:

```
× Failed to build `uharfbuzz==0.45.0`                                                                                                            
├─▶ The build backend returned an error                                                                                                          
╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)   
...
[stderr]
WARNING setuptools_scm.pyproject_reading toml section missing
'pyproject.toml does not contain a tool.setuptools_scm section'
Traceback (most recent call last):
  File
"/root/.cache/uv/builds-v0/.tmp6PFCYC/lib/python3.12/site-packages/setuptools_scm/_integration/pyproject_reading.py",
line 36, in read_pyproject
    section = defn.get("tool", {})[tool_name]
              ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'setuptools_scm'
error: command 'c++' failed: No such file or dir
```

... whether the build would have succeeded after that I admit I have no idea... but the error *does* seem correct according to the [setuptools-scm docs](https://setuptools-scm.readthedocs.io/en/latest/usage/#at-build-time), which state that a table should be included (even if empty)

```toml
[tool.setuptools_scm]
# can be empty if no extra settings are needed, presence enables setuptools-scm
```

(*edit*: i acknowledge that it states a warning, before a KeyError... and it's *still* not entirely clear that the missing table is what actually bombed the build... but it seems like the correct addition anyway)