### PR TITLE
Add an empty [tool.setuptools_scm] section to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+
 [tool.cibuildwheel]
 # Skip unsupported Python versions, and only build for 64-bit on Linux
 skip = ["cp36-*", "cp37-*", "*-manylinux_i686", "*-musllinux_i686"]


### PR DESCRIPTION
See https://setuptools-scm.readthedocs.io/en/latest/usage/. This section is expected to be present, but it may be empty if no non-default settings are required.

This addition does not change the contents of the binary wheels.

Fixes:

```
$ python3 -m build
[…]
WARNING setuptools_scm.pyproject_reading toml section missing 'pyproject.toml does not contain a tool.setuptools_scm section'
Traceback (most recent call last):
  File "/tmp/build-env-sgdlgtss/lib64/python3.13/site-packages/setuptools_scm/_integration/pyproject_reading.py", line 36, in read_pyproject
    section = defn.get("tool", {})[tool_name]
              ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'setuptools_scm'
```