### PR TITLE
[DRAFT] Add a [tool.setuptools_scm] section to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+version_file = "src/uharfbuzz/_version.py"
+
 [tool.cibuildwheel]
 # Skip unsupported Python versions, and only build for 64-bit on Linux
 skip = ["cp36-*", "cp37-*", "*-manylinux_i686", "*-musllinux_i686"]


### PR DESCRIPTION
See https://setuptools-scm.readthedocs.io/en/latest/usage/. This section is expected to be present, but it may be empty if no non-default settings are required.

This addition does not change the contents of the binary wheels.

I had an idea about why https://github.com/harfbuzz/uharfbuzz/pull/231 might have failed, so I’m resuscitating the PR to see what the CI thinks. I configured `version_file` in the new `[tool.setuptools_scm]` section.