### PR TITLE
Skip building PyPy 3.8 wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
+# Skip building PyPy 3.8 wheels, the build currently fails
+skip = ["pp38-*"]
 enable = ["pypy"]
 test-requires = "pytest"
 test-command = "pytest {project}/tests"


### PR DESCRIPTION
The build is suddenly broken even though we changed nothing.