### PR TITLE
Use trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,12 @@ jobs:
     if: contains(github.ref, 'refs/tags/')
     env:
       GH_TOKEN: ${{ github.token }}
+    environment:
+      name: publish-to-pypi
+      url: https://pypi.org/p/uharfbuzz
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -100,9 +106,6 @@ jobs:
                             $notes \
                             $prerelease
     - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         if [ "$IS_PRERELEASE" == true ]; then
           echo "DEBUG: This is a pre-release"


### PR DESCRIPTION
In light of the recent npm supply chain attacks and also https://blog.pypi.org/posts/2025-09-16-github-actions-token-exfiltration/, I'm combing through our font stack to see if all them Py projects are using the trusted publisher mechanism as recommended by PyPI. See https://docs.pypi.org/trusted-publishers/ and https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi.

Someone needs to do two things for this PR to work:

* Create an environment called "publish-to-pypi" in this GitHub repository under Settings -> Environments. Creating alone is probably enough, no configuration needed I think.
* Follow https://docs.pypi.org/trusted-publishers/adding-a-publisher/ to set up the other side on PyPI.

I'm not sure if one needs to do anything to make twine pick up the new creds, trusted publishing should be supported in v6.1.0.