### PR TITLE
Strip debug symbols from Linux wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ skip = ["pp38-*"]
 enable = ["pypy"]
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
-environment = { CFLAGS = "-g0" }
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ def _configure_extensions_with_vendored_libs() -> List[Extension]:
     libraries = []
     if platform.system() != "Windows":
         extra_compile_args.append("-std=c++11")
+        extra_compile_args.append("-g0")
         define_macros.append(("HAVE_MMAP", "1"))
         define_macros.append(("HAVE_UNISTD_H", "1"))
         define_macros.append(("HAVE_SYS_MMAN_H", "1"))


### PR DESCRIPTION
Add -g0 to extra_compile_args to override manylinux Python's default -g flag and prevent debug symbols from being included in wheels.

Setting CFLAGS as environment variable didn't seem to have an effect in those cases.

This is meant to mitigate https://github.com/harfbuzz/uharfbuzz/issues/260