### PR TITLE
Add an empty tool.setuptools_scm section to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+
 [tool.cibuildwheel]
 # Skip unsupported Python versions, and only build for 64-bit on Linux
 skip = ["cp36-*", "cp37-*", "*-manylinux_i686", "*-musllinux_i686"]


### PR DESCRIPTION
Without this, `setuptools_scm` complains about the missing section. This may look like:

```
toml section missing PosixPath('pyproject.toml') does not contain a tool.setuptools_scm section
```

or

```
  WARNING setuptools_scm.pyproject_reading toml section missing 'pyproject.toml does not contain a tool.setuptools_scm section'
  Traceback (most recent call last):
    File "/usr/lib/python3.14/site-packages/setuptools_scm/_integration/pyproject_reading.py", line 36, in read_pyproject
      section = defn.get("tool", {})[tool_name]
                ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  KeyError: 'setuptools_scm'
```

This is harmless, but very easy to fix by adding an empty `tool.setuptools_scm` section.

An alternative would be to depend on `setuptools_scm[simple]`, as described in the “Simplified Activation” section of https://setuptools-scm.readthedocs.io/en/latest/usage/, but this extra is only present in very recent versions of `setuptools_scm`.