### PR TITLE
Pyodide support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,8 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.x"
+        # Pyodide requires Python 3.13 (latest not yet supported)
+        python-version: "3.13"
     - name: Install cibuildwheel
       run: pip install cibuildwheel
     - name: Build Pyodide wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,35 @@ jobs:
         name: uharfbuzz-${{ matrix.os }}
         path: wheelhouse/*.whl
 
+  build-pyodide:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install cibuildwheel
+      run: pip install cibuildwheel
+    - name: Build Pyodide wheel
+      run: python -m cibuildwheel --platform pyodide --output-dir wheelhouse
+    - name: Set up Pyodide venv and run tests
+      run: |
+        pip install pyodide-build
+        pyodide venv .pyodide-venv
+        .pyodide-venv/bin/pip install pytest
+        .pyodide-venv/bin/pip install wheelhouse/*.whl
+        .pyodide-venv/bin/python -m pytest tests/ -v
+    - uses: actions/upload-artifact@v4
+      with:
+        name: uharfbuzz-pyodide
+        path: wheelhouse/*.whl
+
   deploy:
     name: Create and populate release
-    needs: build
+    needs: [build, build-pyodide]
     runs-on: ubuntu-latest
     if: contains(github.ref, 'refs/tags/')
     env:
@@ -69,6 +95,11 @@ jobs:
         for wheel_dir in wheelhouse/uharfbuzz*/; do
           mv "${wheel_dir}"/*.whl dist/
         done
+        # Separate Pyodide wheels (PyPI doesn't accept wasm32 wheels yet)
+        # https://github.com/pypi/warehouse/issues/10416
+        # https://discuss.python.org/t/pep-783-emscripten-packaging
+        mkdir -p dist-pyodide/
+        mv dist/*pyodide*.whl dist-pyodide/ 2>/dev/null || true
     - name: Extract release notes from annotated tag message
       id: release_notes
       env:
@@ -106,6 +137,11 @@ jobs:
                             --title "${{ env.RELEASE_NAME }}" \
                             $notes \
                             $prerelease
+    - name: Upload Pyodide wheel to GitHub release
+      run: |
+        if [ -d dist-pyodide ] && [ "$(ls -A dist-pyodide)" ]; then
+          gh release upload ${{ github.ref }} dist-pyodide/*.whl
+        fi
     - name: Build sdist
       run: |
         if [ "$IS_PRERELEASE" == true ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,19 +45,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        # Pyodide requires Python 3.13 (latest not yet supported)
+        # Must match Pyodide's Python version (0.28.x uses 3.13)
         python-version: "3.13"
     - name: Install cibuildwheel
       run: pip install cibuildwheel
-    - name: Build Pyodide wheel
+    - name: Build and test Pyodide wheel
       run: python -m cibuildwheel --platform pyodide --output-dir wheelhouse
-    - name: Set up Pyodide venv and run tests
-      run: |
-        pip install pyodide-build
-        pyodide venv .pyodide-venv
-        .pyodide-venv/bin/pip install pytest
-        .pyodide-venv/bin/pip install wheelhouse/*.whl
-        .pyodide-venv/bin/python -m pytest tests/ -v
     - uses: actions/upload-artifact@v4
       with:
         name: uharfbuzz-pyodide

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,20 @@
 # -*- coding: utf-8 -*-
 import os
 import platform
+import sys
 from io import open
 from typing import List
 
 from Cython.Build import cythonize
 from setuptools import Extension, setup
+
+
+def is_emscripten_build() -> bool:
+    """Detect if we're building for Emscripten/Pyodide."""
+    return (
+        sys.platform == "emscripten"
+        or os.environ.get("_PYTHON_HOST_PLATFORM", "").startswith("emscripten")
+    )
 
 
 def bool_from_environ(key: str, default: bool = False):
@@ -96,50 +105,57 @@ def _configure_extensions_with_vendored_libs() -> List[Extension]:
     # like VARC table support, but we must not use any experimental APIs as it
     # will break linking with system HarfBuzz that is built without these APIs.
     define_macros = [("HB_NO_MT", "1"), ("HB_EXPERIMENTAL_API", "1")]
-    if use_cython_linetrace:
-        define_macros.append(("CYTHON_TRACE_NOGIL", "1"))
-
-    if use_py_limited_api:
-        define_macros.append(("Py_LIMITED_API", limited_api_min_version))
-
     extra_compile_args = []
     extra_link_args = []
     libraries = []
-    if platform.system() != "Windows":
+    sources = ["harfbuzz/src/harfbuzz-subset.cc", "src/uharfbuzz/_harfbuzz.pyx"]
+
+    emscripten = is_emscripten_build()
+
+    if use_cython_linetrace:
+        define_macros.append(("CYTHON_TRACE_NOGIL", "1"))
+
+    limited_api = use_py_limited_api
+    if limited_api:
+        define_macros.append(("Py_LIMITED_API", limited_api_min_version))
+
+    if platform.system() == "Windows" and not emscripten:
+        define_macros.append(("HAVE_DIRECTWRITE", "1"))
+        define_macros.append(("HAVE_UNISCRIBE", "1"))
+        libraries += ["usp10", "gdi32", "user32", "rpcrt4", "dwrite"]
+        sources += [
+            "harfbuzz/src/hb-directwrite.cc",
+            "harfbuzz/src/hb-directwrite-font.cc",
+            "harfbuzz/src/hb-directwrite-shape.cc",
+            "harfbuzz/src/hb-uniscribe.cc",
+        ]
+    else:
         extra_compile_args.append("-std=c++11")
         extra_compile_args.append("-g0")
         define_macros.append(("HAVE_MMAP", "1"))
         define_macros.append(("HAVE_UNISTD_H", "1"))
         define_macros.append(("HAVE_SYS_MMAN_H", "1"))
-    else:
-        define_macros.append(("HAVE_DIRECTWRITE", "1"))
-        define_macros.append(("HAVE_UNISCRIBE", "1"))
-        libraries += ["usp10", "gdi32", "user32", "rpcrt4", "dwrite"]
 
-    if platform.system() == "Darwin":
+    if platform.system() == "Darwin" and not emscripten:
         define_macros.append(("HAVE_CORETEXT", "1"))
         extra_link_args.extend(["-framework", "ApplicationServices"])
+        sources += [
+            "harfbuzz/src/hb-coretext.cc",
+            "harfbuzz/src/hb-coretext-font.cc",
+            "harfbuzz/src/hb-coretext-shape.cc",
+        ]
+
 
     extension = Extension(
         "uharfbuzz._harfbuzz",
         define_macros=define_macros,
         include_dirs=["harfbuzz/src"],
-        sources=[
-            "harfbuzz/src/harfbuzz-subset.cc",
-            "harfbuzz/src/hb-coretext.cc",
-            "harfbuzz/src/hb-coretext-font.cc",
-            "harfbuzz/src/hb-coretext-shape.cc",
-            "harfbuzz/src/hb-directwrite.cc",
-            "harfbuzz/src/hb-directwrite-font.cc",
-            "harfbuzz/src/hb-directwrite-shape.cc",
-            "harfbuzz/src/hb-uniscribe.cc",
-            "src/uharfbuzz/_harfbuzz.pyx",
-        ],
+        sources=sources,
         language="c++",
         libraries=libraries,
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
-        py_limited_api=use_py_limited_api,
+        py_limited_api=limited_api,
     )
 
     extension_test = Extension(
@@ -154,7 +170,7 @@ def _configure_extensions_with_vendored_libs() -> List[Extension]:
         libraries=libraries,
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
-        py_limited_api=use_py_limited_api,
+        py_limited_api=limited_api,
     )
 
     return [extension, extension_test]

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,37 @@ changedir = {toxinidir}
 commands =
     sphinx-build -j auto docs/source/ docs/build/
 
+[testenv:pyodide]
+description = build and test Pyodide wheel
+# Emscripten SDK is cached globally by pyodide-build:
+#   Linux: ~/.pyodide-xbuildenv-{version}/{pyodide-version}/emsdk
+#   macOS: ~/Library/Caches/.pyodide-xbuildenv-{version}/{pyodide-version}/emsdk
+skip_install = true
+allowlist_externals =
+    bash
+    {envtmpdir}/.pyodide-venv/bin/pip
+    {envtmpdir}/.pyodide-venv/bin/python
+deps =
+    pyodide-build
+passenv =
+    HOME
+changedir = {toxinidir}
+commands =
+    # avoid re-downloading emsdk if already cached
+    bash -c '\
+        find_emsdk() { \
+            for p in "$HOME/.pyodide-xbuildenv"-*/*/emsdk "$HOME/Library/Caches/.pyodide-xbuildenv"-*/*/emsdk; do \
+                [ -d "$p" ] && echo "$p" && return; \
+            done; \
+        }; \
+        EMSDK=$(find_emsdk); \
+        [ -z "$EMSDK" ] && pyodide xbuildenv install-emscripten && EMSDK=$(find_emsdk); \
+        source "$EMSDK/emsdk_env.sh" 2>/dev/null && \
+        pyodide build --outdir {envtmpdir}/dist'
+    pyodide venv {envtmpdir}/.pyodide-venv
+    bash -c '{envtmpdir}/.pyodide-venv/bin/pip install pytest {envtmpdir}/dist/uharfbuzz*.whl'
+    {envtmpdir}/.pyodide-venv/bin/python -m pytest {posargs}
+
 [pytest]
 testpaths = tests/
 addopts =


### PR DESCRIPTION
- Detect Emscripten cross-compilation in setup.py, skipping platform-specific sources (CoreText, DirectWrite, Uniscribe)
- Add build-pyodide job to CI workflow
- Upload Pyodide wheel to GitHub releases only (PyPI doesn't accept wasm32 wheels yet, see https://github.com/pypi/warehouse/issues/10416 and https://discuss.python.org/t/pep-783-emscripten-packaging)
- Also add `tox -e pyodide` for local build and test

Fixes #270 