### PR TITLE
When using system Harfbuzz, link the harfbuzz-raster component

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def _configure_extensions_with_system_libs() -> List[Extension]:
     libraries = []
     library_dirs = []
 
-    harfbuzz_components = ["harfbuzz-subset"]
+    harfbuzz_components = ["harfbuzz-subset", "harfbuzz-raster"]
     for harfbuzz_component in harfbuzz_components:
         harfbuzz_component_configuration = pkgconfig.parse(harfbuzz_component)
         include_dirs += harfbuzz_component_configuration["include_dirs"]


### PR DESCRIPTION
This fixes errors like `ImportError: […]/uharfbuzz/_harfbuzz.abi3.so: undefined symbol: hb_raster_image_get_extents
` since 29d1e9634ee383739a7d5fb992534d5457927f0d.